### PR TITLE
docs: Enhance documentation for External-DNS integration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,82 @@
+version: '3.8'
+
+services:
+  njalla-webhook:
+    image: ghcr.io/douglaz/njalla-webhook:latest
+    container_name: njalla-webhook
+    environment:
+      # Required: Your Njalla API token
+      NJALLA_API_TOKEN: ${NJALLA_API_TOKEN}
+
+      # Optional: Comma-separated list of domains to manage
+      # Leave empty to manage all domains in your Njalla account
+      DOMAIN_FILTER: ${DOMAIN_FILTER:-}
+
+      # Webhook server configuration
+      WEBHOOK_HOST: ${WEBHOOK_HOST:-0.0.0.0}
+      WEBHOOK_PORT: ${WEBHOOK_PORT:-8888}
+
+      # Logging level: trace, debug, info, warn, error
+      RUST_LOG: ${RUST_LOG:-info}
+
+      # Dry run mode - set to true to test without making changes
+      DRY_RUN: ${DRY_RUN:-false}
+
+      # Cache TTL for DNS records (seconds)
+      CACHE_TTL_SECONDS: ${CACHE_TTL_SECONDS:-60}
+
+    ports:
+      # Expose webhook port
+      - "${WEBHOOK_EXTERNAL_PORT:-8888}:8888"
+
+    restart: unless-stopped
+
+    # Health check
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8888/healthz"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+
+    # Resource limits
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+          cpus: '0.5'
+        reservations:
+          memory: 64M
+          cpus: '0.1'
+
+    # Logging configuration
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  # Optional: External-DNS container for local testing
+  # Uncomment to run external-dns alongside the webhook
+  # external-dns:
+  #   image: registry.k8s.io/external-dns/external-dns:v0.14.0
+  #   container_name: external-dns
+  #   command:
+  #     - --source=service
+  #     - --source=ingress
+  #     - --provider=webhook
+  #     - --webhook-provider-url=http://njalla-webhook:8888
+  #     - --domain-filter=${DOMAIN_FILTER:-}
+  #     - --registry=txt
+  #     - --txt-owner-id=external-dns
+  #     - --log-level=info
+  #     - --interval=30s
+  #   depends_on:
+  #     - njalla-webhook
+  #   restart: unless-stopped
+
+# Optional: Create a network for better isolation
+networks:
+  default:
+    name: external-dns-network
+    driver: bridge

--- a/examples/kubernetes/complete-deployment.yaml
+++ b/examples/kubernetes/complete-deployment.yaml
@@ -1,0 +1,281 @@
+# Complete Njalla Webhook + External-DNS Deployment for Kubernetes
+# This manifest creates everything needed to use External-DNS with Njalla domains
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: external-dns
+  labels:
+    name: external-dns
+---
+# Store your Njalla API token securely
+# Get your token from: https://njal.la/settings/api/
+apiVersion: v1
+kind: Secret
+metadata:
+  name: njalla-api-credentials
+  namespace: external-dns
+type: Opaque
+stringData:
+  # IMPORTANT: Replace with your actual Njalla API token
+  api-token: "your-njalla-api-token-here"
+---
+# ServiceAccount for External-DNS
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: external-dns
+  namespace: external-dns
+---
+# ClusterRole with necessary permissions for External-DNS
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-dns
+rules:
+- apiGroups: [""]
+  resources: ["services", "endpoints", "pods"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: ["extensions", "networking.k8s.io"]
+  resources: ["ingresses"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["list"]
+---
+# Bind the ClusterRole to the ServiceAccount
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: external-dns
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-dns
+subjects:
+- kind: ServiceAccount
+  name: external-dns
+  namespace: external-dns
+---
+# Deploy the Njalla Webhook server
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: njalla-webhook
+  namespace: external-dns
+  labels:
+    app: njalla-webhook
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: njalla-webhook
+  template:
+    metadata:
+      labels:
+        app: njalla-webhook
+    spec:
+      containers:
+      - name: njalla-webhook
+        # Use a specific version tag for production
+        image: ghcr.io/douglaz/njalla-webhook:latest
+        imagePullPolicy: IfNotPresent
+        ports:
+        - name: http
+          containerPort: 8888
+          protocol: TCP
+        env:
+        # Required: Njalla API token
+        - name: NJALLA_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: njalla-api-credentials
+              key: api-token
+        # Webhook server configuration
+        - name: WEBHOOK_HOST
+          value: "0.0.0.0"
+        - name: WEBHOOK_PORT
+          value: "8888"
+        # IMPORTANT: Update with your domains
+        # This must match the domain-filter in external-dns
+        - name: DOMAIN_FILTER
+          value: "example.com,example.org"
+        # Logging configuration
+        - name: RUST_LOG
+          value: "info"
+        # Set to true to test without making actual changes
+        - name: DRY_RUN
+          value: "false"
+        # Health checks
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8888
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8888
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 3
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "50m"
+          limits:
+            memory: "256Mi"
+            cpu: "200m"
+---
+# Service to expose the webhook within the cluster
+apiVersion: v1
+kind: Service
+metadata:
+  name: njalla-webhook
+  namespace: external-dns
+  labels:
+    app: njalla-webhook
+spec:
+  type: ClusterIP
+  selector:
+    app: njalla-webhook
+  ports:
+  - name: http
+    port: 8888
+    targetPort: 8888
+    protocol: TCP
+---
+# Deploy External-DNS configured to use the webhook
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: external-dns
+  namespace: external-dns
+  labels:
+    app: external-dns
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: external-dns
+  template:
+    metadata:
+      labels:
+        app: external-dns
+    spec:
+      serviceAccountName: external-dns
+      containers:
+      - name: external-dns
+        image: registry.k8s.io/external-dns/external-dns:v0.14.0
+        args:
+        # Sources to watch for DNS entries
+        - --source=ingress
+        - --source=service
+        # Webhook provider configuration
+        - --provider=webhook
+        - --webhook-provider-url=http://njalla-webhook:8888
+        # IMPORTANT: Update with your domains
+        # Must match the DOMAIN_FILTER in njalla-webhook
+        - --domain-filter=example.com
+        - --domain-filter=example.org
+        # TXT registry for ownership records
+        - --registry=txt
+        - --txt-owner-id=njalla-webhook
+        - --txt-prefix=_externaldns.
+        # Sync configuration
+        - --interval=1m
+        - --log-level=info
+        - --log-format=text
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "50m"
+          limits:
+            memory: "256Mi"
+            cpu: "200m"
+---
+# Optional: NetworkPolicy for security
+# Uncomment if you use NetworkPolicies in your cluster
+# ---
+# apiVersion: networking.k8s.io/v1
+# kind: NetworkPolicy
+# metadata:
+#   name: njalla-webhook-network-policy
+#   namespace: external-dns
+# spec:
+#   podSelector:
+#     matchLabels:
+#       app: njalla-webhook
+#   policyTypes:
+#   - Ingress
+#   - Egress
+#   ingress:
+#   # Allow traffic from external-dns
+#   - from:
+#     - podSelector:
+#         matchLabels:
+#           app: external-dns
+#     ports:
+#     - protocol: TCP
+#       port: 8888
+#   egress:
+#   # Allow DNS resolution
+#   - to:
+#     - namespaceSelector: {}
+#       podSelector:
+#         matchLabels:
+#           k8s-app: kube-dns
+#     ports:
+#     - protocol: TCP
+#       port: 53
+#     - protocol: UDP
+#       port: 53
+#   # Allow HTTPS traffic to Njalla API
+#   - ports:
+#     - protocol: TCP
+#       port: 443
+# ---
+# apiVersion: networking.k8s.io/v1
+# kind: NetworkPolicy
+# metadata:
+#   name: external-dns-network-policy
+#   namespace: external-dns
+# spec:
+#   podSelector:
+#     matchLabels:
+#       app: external-dns
+#   policyTypes:
+#   - Egress
+#   egress:
+#   # Allow DNS resolution
+#   - to:
+#     - namespaceSelector: {}
+#       podSelector:
+#         matchLabels:
+#           k8s-app: kube-dns
+#     ports:
+#     - protocol: TCP
+#       port: 53
+#     - protocol: UDP
+#       port: 53
+#   # Allow connection to webhook
+#   - to:
+#     - podSelector:
+#         matchLabels:
+#           app: njalla-webhook
+#     ports:
+#     - protocol: TCP
+#       port: 8888
+#   # Allow access to Kubernetes API
+#   - ports:
+#     - protocol: TCP
+#       port: 443
+#     - protocol: TCP
+#       port: 6443

--- a/examples/kubernetes/test-ingress.yaml
+++ b/examples/kubernetes/test-ingress.yaml
@@ -1,0 +1,193 @@
+# Example Ingress resources to test External-DNS with Njalla
+# These will automatically create DNS records in your Njalla domains
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: example-app
+  namespace: default
+  annotations:
+    # Optional: Explicitly set the hostname
+    # If not set, uses spec.rules[].host
+    external-dns.alpha.kubernetes.io/hostname: app.example.com
+    # Optional: Set custom TTL (in seconds)
+    external-dns.alpha.kubernetes.io/ttl: "300"
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: app.example.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: example-service
+            port:
+              number: 80
+  tls:
+  - hosts:
+    - app.example.com
+    secretName: app-example-com-tls
+---
+# Example with multiple hosts
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: multi-host-app
+  namespace: default
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: www.example.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: web-service
+            port:
+              number: 80
+  - host: api.example.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: api-service
+            port:
+              number: 8080
+  - host: admin.example.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: admin-service
+            port:
+              number: 3000
+  tls:
+  - hosts:
+    - www.example.com
+    - api.example.com
+    - admin.example.com
+    secretName: example-com-tls
+---
+# Example with wildcard certificate
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: wildcard-app
+  namespace: default
+  annotations:
+    # For wildcard certificates with cert-manager
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: "*.apps.example.com"
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: wildcard-service
+            port:
+              number: 80
+  tls:
+  - hosts:
+    - "*.apps.example.com"
+    secretName: wildcard-apps-example-com-tls
+---
+# Example Service with LoadBalancer (if supported by your cloud provider)
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-loadbalancer
+  namespace: default
+  annotations:
+    # This will create an A record pointing to the LoadBalancer IP
+    external-dns.alpha.kubernetes.io/hostname: lb.example.com
+spec:
+  type: LoadBalancer
+  selector:
+    app: example-app
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+---
+# Example Service with explicit target
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-external
+  namespace: default
+  annotations:
+    # Create a CNAME record pointing to an external service
+    external-dns.alpha.kubernetes.io/hostname: external.example.com
+    external-dns.alpha.kubernetes.io/target: some-external-service.amazonaws.com
+spec:
+  type: ExternalName
+  externalName: some-external-service.amazonaws.com
+---
+# Test application deployment (nginx)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-app
+  namespace: default
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: example-app
+  template:
+    metadata:
+      labels:
+        app: example-app
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:alpine
+        ports:
+        - containerPort: 80
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "50m"
+          limits:
+            memory: "128Mi"
+            cpu: "100m"
+---
+# Service for the test application
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-service
+  namespace: default
+spec:
+  selector:
+    app: example-app
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+---
+# Instructions for testing:
+#
+# 1. Update the domain names in this file to match your actual Njalla domains
+# 2. Apply this manifest: kubectl apply -f test-ingress.yaml
+# 3. Check External-DNS logs: kubectl logs -n external-dns deployment/external-dns
+# 4. Check Njalla webhook logs: kubectl logs -n external-dns deployment/njalla-webhook
+# 5. Verify DNS records are created: nslookup app.example.com
+# 6. Test with curl: curl -H "Host: app.example.com" http://<ingress-controller-ip>
+#
+# To see what records will be created without actually creating them:
+# 1. Set DRY_RUN=true in the njalla-webhook deployment
+# 2. Apply your ingress/service
+# 3. Check the webhook logs to see what would have been created


### PR DESCRIPTION
## Summary
This PR significantly enhances the documentation for the njalla-webhook project, making it much easier for users to deploy and integrate with External-DNS in Kubernetes clusters.

## Changes
- 📚 **Completely rewrote README.md** with comprehensive integration guide
- 🔍 Added detailed troubleshooting section with common issues and solutions
- ⚡ Included performance benchmarks and security considerations
- 🚀 Created production-ready Kubernetes deployment manifests
- 🐳 Added `docker-compose.yml` for easy local testing
- 📝 Provided multiple ingress configuration examples
- 🔌 Documented all API endpoints and webhook protocol
- 📖 Added step-by-step deployment instructions

## New Files
- `docker-compose.yml` - Docker Compose configuration for local development
- `examples/kubernetes/complete-deployment.yaml` - Full production deployment
- `examples/kubernetes/test-ingress.yaml` - Example ingress configurations

## Benefits
This documentation update makes it much easier for users to:
1. Understand how njalla-webhook works with External-DNS
2. Deploy the webhook in production Kubernetes clusters
3. Debug common integration issues
4. Test locally with Docker Compose
5. Configure various DNS record types through Kubernetes resources

## Testing
- [x] Documentation reviewed for clarity and accuracy
- [x] Example configurations validated
- [x] Kubernetes manifests syntax checked
- [x] Docker Compose configuration tested