### PR TITLE
fix(config): enforce exact domain-filter boundaries

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -27,7 +27,7 @@ impl Config {
 
         let domain_filter = env::var("DOMAIN_FILTER").ok().map(|s| {
             s.split(',')
-                .map(|d| d.trim().to_string())
+                .map(|d| Self::normalize_domain(d.trim()))
                 .filter(|d| !d.is_empty())
                 .collect()
         });
@@ -52,8 +52,100 @@ impl Config {
 
     pub fn is_domain_allowed(&self, domain: &str) -> bool {
         match &self.domain_filter {
-            Some(filter) => filter.iter().any(|d| domain.ends_with(d)),
+            Some(filter) => {
+                let domain = Self::normalize_domain(domain);
+                filter
+                    .iter()
+                    .any(|d| domain == *d || domain.ends_with(&format!(".{d}")))
+            }
             None => true,
         }
+    }
+
+    /// Canonicalize a domain name: strip trailing dot and lowercase.
+    pub(crate) fn normalize_domain(s: &str) -> String {
+        s.strip_suffix('.').unwrap_or(s).to_ascii_lowercase()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config_with_filter(domains: Vec<&str>) -> Config {
+        Config {
+            njalla_api_token: String::new(),
+            webhook_host: String::new(),
+            webhook_port: 8888,
+            domain_filter: Some(
+                domains
+                    .into_iter()
+                    .map(|d| Config::normalize_domain(d))
+                    .collect(),
+            ),
+            dry_run: false,
+            cache_ttl_seconds: 60,
+        }
+    }
+
+    #[test]
+    fn exact_match_is_allowed() {
+        let config = config_with_filter(vec!["example.com"]);
+        assert!(config.is_domain_allowed("example.com"));
+    }
+
+    #[test]
+    fn proper_subdomain_is_allowed() {
+        let config = config_with_filter(vec!["example.com"]);
+        assert!(config.is_domain_allowed("www.example.com"));
+    }
+
+    #[test]
+    fn nested_subdomain_is_allowed() {
+        let config = config_with_filter(vec!["example.com"]);
+        assert!(config.is_domain_allowed("sub.deep.example.com"));
+    }
+
+    #[test]
+    fn sibling_domain_is_rejected() {
+        let config = config_with_filter(vec!["example.com"]);
+        assert!(!config.is_domain_allowed("badexample.com"));
+    }
+
+    #[test]
+    fn another_sibling_domain_is_rejected() {
+        let config = config_with_filter(vec!["example.com"]);
+        assert!(!config.is_domain_allowed("notexample.com"));
+    }
+
+    #[test]
+    fn case_insensitive_match() {
+        let config = config_with_filter(vec!["example.com"]);
+        assert!(config.is_domain_allowed("WWW.Example.COM"));
+    }
+
+    #[test]
+    fn trailing_dot_on_domain() {
+        let config = config_with_filter(vec!["example.com"]);
+        assert!(config.is_domain_allowed("www.example.com."));
+    }
+
+    #[test]
+    fn trailing_dot_on_filter() {
+        let config = config_with_filter(vec!["example.com."]);
+        assert!(config.is_domain_allowed("www.example.com"));
+    }
+
+    #[test]
+    fn none_filter_allows_all() {
+        let config = Config {
+            njalla_api_token: String::new(),
+            webhook_host: String::new(),
+            webhook_port: 8888,
+            domain_filter: None,
+            dry_run: false,
+            cache_ttl_seconds: 60,
+        };
+        assert!(config.is_domain_allowed("anything.com"));
     }
 }

--- a/src/webhook/handlers.rs
+++ b/src/webhook/handlers.rs
@@ -231,6 +231,7 @@ impl WebhookHandler {
             );
         }
 
+        // NOTE: partial failures still return NO_CONTENT (br-nyy.2)
         Ok(StatusCode::NO_CONTENT)
     }
 
@@ -326,17 +327,24 @@ impl WebhookHandler {
     }
 
     fn extract_zone(&self, dns_name: &str) -> Result<String> {
+        // Normalize dns_name; filter entries are already canonical from Config::from_env
+        let normalized_name = dns_name
+            .strip_suffix('.')
+            .unwrap_or(dns_name)
+            .to_ascii_lowercase();
+
         // Find the zone by checking against configured domains
         if let Some(ref domains) = self.config.domain_filter {
             for domain in domains {
-                if dns_name == domain || dns_name.ends_with(&format!(".{}", domain)) {
+                if normalized_name == *domain || normalized_name.ends_with(&format!(".{}", domain))
+                {
                     return Ok(domain.clone());
                 }
             }
         }
 
         // Fall back to extracting last two parts as zone
-        let parts: Vec<&str> = dns_name.split('.').collect();
+        let parts: Vec<&str> = normalized_name.split('.').collect();
         if parts.len() >= 2 {
             Ok(format!(
                 "{}.{}",
@@ -352,12 +360,17 @@ impl WebhookHandler {
     }
 
     fn extract_record_name(&self, dns_name: &str, zone: &str) -> String {
-        if dns_name == zone {
+        // Normalize dns_name to match the canonical zone returned by extract_zone
+        let normalized = dns_name
+            .strip_suffix('.')
+            .unwrap_or(dns_name)
+            .to_ascii_lowercase();
+        if normalized == zone {
             "".to_string()
-        } else if dns_name.ends_with(&format!(".{}", zone)) {
-            dns_name[..dns_name.len() - zone.len() - 1].to_string()
+        } else if normalized.ends_with(&format!(".{}", zone)) {
+            normalized[..normalized.len() - zone.len() - 1].to_string()
         } else {
-            dns_name.to_string()
+            normalized
         }
     }
 }
@@ -372,13 +385,90 @@ mod tests {
             njalla_api_token: "dummy-token".to_string(),
             webhook_host: "127.0.0.1".to_string(),
             webhook_port: 8888,
-            domain_filter: Some(vec!["example.com".to_string()]),
+            domain_filter: Some(vec![Config::normalize_domain("example.com")]),
             dry_run: true,
             cache_ttl_seconds: 60,
         };
 
         let client = Arc::new(NjallaClient::new("dummy-token").expect("client should build"));
         WebhookHandler::new(client, config)
+    }
+
+    fn handler_with_filter(domains: Vec<&str>) -> WebhookHandler {
+        let config = Config {
+            njalla_api_token: "dummy-token".to_string(),
+            webhook_host: "127.0.0.1".to_string(),
+            webhook_port: 8888,
+            domain_filter: Some(
+                domains
+                    .into_iter()
+                    .map(|d| Config::normalize_domain(d))
+                    .collect(),
+            ),
+            dry_run: true,
+            cache_ttl_seconds: 60,
+        };
+        let client = Arc::new(NjallaClient::new("dummy-token").expect("client should build"));
+        WebhookHandler::new(client, config)
+    }
+
+    #[test]
+    fn extract_zone_returns_canonical_zone() {
+        let handler = test_handler();
+        let zone = handler.extract_zone("www.example.com").unwrap();
+        assert_eq!(zone, "example.com");
+    }
+
+    #[test]
+    fn extract_zone_mixed_case_filter() {
+        let handler = handler_with_filter(vec!["Example.COM"]);
+        let zone = handler.extract_zone("www.example.com").unwrap();
+        assert_eq!(zone, "example.com");
+    }
+
+    #[test]
+    fn extract_zone_trailing_dot_filter() {
+        let handler = handler_with_filter(vec!["example.com."]);
+        let zone = handler.extract_zone("www.example.com").unwrap();
+        assert_eq!(zone, "example.com");
+    }
+
+    #[test]
+    fn extract_zone_trailing_dot_dns_name() {
+        let handler = test_handler();
+        let zone = handler.extract_zone("www.example.com.").unwrap();
+        assert_eq!(zone, "example.com");
+    }
+
+    #[test]
+    fn extract_zone_fallback_strips_trailing_dot() {
+        let handler = handler_with_filter(vec!["other.com"]);
+        let zone = handler.extract_zone("www.fallback.org.").unwrap();
+        assert_eq!(zone, "fallback.org");
+    }
+
+    #[test]
+    fn extract_record_name_with_mixed_case() {
+        let handler = handler_with_filter(vec!["Example.COM"]);
+        let zone = handler.extract_zone("WWW.Example.COM").unwrap();
+        let name = handler.extract_record_name("WWW.Example.COM", &zone);
+        assert_eq!(name, "www");
+    }
+
+    #[test]
+    fn extract_record_name_with_trailing_dot() {
+        let handler = test_handler();
+        let zone = handler.extract_zone("app.example.com.").unwrap();
+        let name = handler.extract_record_name("app.example.com.", &zone);
+        assert_eq!(name, "app");
+    }
+
+    #[test]
+    fn extract_record_name_exact_zone_match() {
+        let handler = test_handler();
+        let zone = handler.extract_zone("example.com").unwrap();
+        let name = handler.extract_record_name("example.com", &zone);
+        assert_eq!(name, "");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Fix `is_domain_allowed` to require exact zone match or proper subdomain (`.` boundary), rejecting sibling domains like `badexample.com` matching filter `example.com`
- Add DNS normalization (trailing dot stripping, case-insensitive) to both the config parser and domain checks
- Apply same normalization to `extract_zone` and `extract_record_name` in handlers for consistency

Closes br-nyy.3 from the initial code review audit.

## Test plan
- [x] Exact match allowed (`example.com` vs filter `example.com`)
- [x] Proper subdomain allowed (`www.example.com`)
- [x] Nested subdomain allowed (`sub.deep.example.com`)
- [x] Sibling domain rejected (`badexample.com`)
- [x] Case-insensitive matching (`WWW.Example.COM`)
- [x] Trailing dot handling (both input and filter)
- [x] None filter allows all domains
- [x] Handler zone extraction with normalization
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean