### PR TITLE
fix(nix): align Docker healthcheck with actual /healthz route

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -121,7 +121,7 @@
                 "org.opencontainers.image.licenses" = "MIT";
               };
               Healthcheck = {
-                Test = ["CMD" "${pkgs.coreutils}/bin/timeout" "5" "${pkgs.coreutils}/bin/sh" "-c" "echo -e 'GET /health HTTP/1.1\\r\\nHost: localhost\\r\\n\\r\\n' | ${pkgs.coreutils}/bin/nc 127.0.0.1 8888 | ${pkgs.coreutils}/bin/grep -q '200 OK'"];
+                Test = ["CMD" "/bin/wget" "--no-verbose" "--tries=1" "--spider" "http://localhost:8888/healthz"];
                 Interval = 30000000000; # 30 seconds in nanoseconds
                 Timeout = 5000000000;   # 5 seconds in nanoseconds
                 Retries = 3;


### PR DESCRIPTION
## Summary

- Fix Docker healthcheck in `flake.nix` to probe `/healthz` instead of non-existent `/health`
- Simplify healthcheck from manual `nc` + `grep` pipeline to `wget --spider`

The container was reporting unhealthy even when the webhook was running fine because the healthcheck hit a 404 on `/health`.

Closes br-nyy.5 from the initial code review audit.

## Test plan
- [x] Verified `wget` is already in the Docker image (`pkgs.wget`)
- [x] Verified `/healthz` is the actual route in `src/webhook/routes.rs`
- [x] `cargo test` / `cargo clippy` / `cargo fmt --check` pass