### PR TITLE
fix(webhook): return error on partial apply_changes failure

### DIFF
--- a/src/webhook/handlers.rs
+++ b/src/webhook/handlers.rs
@@ -213,15 +213,9 @@ impl WebhookHandler {
             }
         }
 
-        if !errors.is_empty() && applied_count == 0 {
-            return Err(Error::Internal(format!(
-                "All operations failed: {:?}",
-                errors
-            )));
-        }
-
         if errors.is_empty() {
             info!("Successfully applied {} changes", applied_count);
+            Ok(StatusCode::NO_CONTENT)
         } else {
             error!(
                 "Applied {} changes with {} errors: {:?}",
@@ -229,10 +223,13 @@ impl WebhookHandler {
                 errors.len(),
                 errors
             );
+            Err(Error::Internal(format!(
+                "Partial failure: {} succeeded, {} failed: {:?}",
+                applied_count,
+                errors.len(),
+                errors
+            )))
         }
-
-        // NOTE: partial failures still return NO_CONTENT (br-nyy.2)
-        Ok(StatusCode::NO_CONTENT)
     }
 
     pub async fn adjust_endpoints(
@@ -469,6 +466,82 @@ mod tests {
         let zone = handler.extract_zone("example.com").unwrap();
         let name = handler.extract_record_name("example.com", &zone);
         assert_eq!(name, "");
+    }
+
+    #[tokio::test]
+    async fn apply_changes_returns_error_on_partial_failure() {
+        let handler = test_handler();
+        let request: ApplyChangesRequest = serde_json::from_value(json!({
+            "create": [
+                {
+                    "dnsName": "app.example.com",
+                    "targets": ["192.0.2.10"],
+                    "recordType": "A"
+                },
+                {
+                    "dnsName": "app.blocked.com",
+                    "targets": ["192.0.2.11"],
+                    "recordType": "A"
+                }
+            ]
+        }))
+        .expect("payload should deserialize");
+
+        let err = handler
+            .apply_changes(Json(request))
+            .await
+            .expect_err("partial failure should return error");
+        assert!(
+            matches!(err, Error::Internal(_)),
+            "expected Error::Internal, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn apply_changes_returns_no_content_on_empty_changes() {
+        let handler = test_handler();
+        let request: ApplyChangesRequest = serde_json::from_value(json!({
+            "create": [],
+            "updateOld": [],
+            "updateNew": [],
+            "delete": []
+        }))
+        .expect("payload should deserialize");
+
+        let status = handler
+            .apply_changes(Json(request))
+            .await
+            .expect("empty changes should succeed");
+        assert_eq!(status, StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    async fn apply_changes_returns_error_when_all_operations_fail() {
+        let handler = test_handler();
+        let request: ApplyChangesRequest = serde_json::from_value(json!({
+            "create": [
+                {
+                    "dnsName": "app.blocked.com",
+                    "targets": ["192.0.2.10"],
+                    "recordType": "A"
+                },
+                {
+                    "dnsName": "app.other.com",
+                    "targets": ["192.0.2.11"],
+                    "recordType": "A"
+                }
+            ]
+        }))
+        .expect("payload should deserialize");
+
+        let err = handler
+            .apply_changes(Json(request))
+            .await
+            .expect_err("all-disallowed should return error");
+        assert!(
+            matches!(err, Error::Internal(_)),
+            "expected Error::Internal, got: {err:?}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Return `500 Internal Server Error` instead of `204 No Content` when some operations succeed but others fail (partial failure)
- Simplify the error/success branching — the old separate all-failures check is folded into the unified else branch
- Add tests for partial failure, all-failure, and empty-changes scenarios

Previously, external-dns received a 204 success signal even when DNS state was left incomplete (e.g., delete succeeded but re-create failed during an update). Now the reconciler will retry on the next loop.

Closes br-nyy.2 from the initial code review audit.

## Test plan
- [x] `apply_changes_returns_error_on_partial_failure` — mixed allowed/disallowed domains
- [x] `apply_changes_returns_error_when_all_operations_fail` — all disallowed domains
- [x] `apply_changes_returns_no_content_on_empty_changes` — empty payload
- [x] `apply_changes_accepts_external_dns_payload_and_returns_no_content` — all succeed (existing)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean