### PR TITLE
fix: replace redundant closures with function references

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -77,12 +77,7 @@ mod tests {
             njalla_api_token: String::new(),
             webhook_host: String::new(),
             webhook_port: 8888,
-            domain_filter: Some(
-                domains
-                    .into_iter()
-                    .map(|d| Config::normalize_domain(d))
-                    .collect(),
-            ),
+            domain_filter: Some(domains.into_iter().map(Config::normalize_domain).collect()),
             dry_run: false,
             cache_ttl_seconds: 60,
         }

--- a/src/webhook/handlers.rs
+++ b/src/webhook/handlers.rs
@@ -486,12 +486,7 @@ mod tests {
             njalla_api_token: "dummy-token".to_string(),
             webhook_host: "127.0.0.1".to_string(),
             webhook_port: 8888,
-            domain_filter: Some(
-                domains
-                    .into_iter()
-                    .map(|d| Config::normalize_domain(d))
-                    .collect(),
-            ),
+            domain_filter: Some(domains.into_iter().map(Config::normalize_domain).collect()),
             dry_run: true,
             cache_ttl_seconds: 60,
         };


### PR DESCRIPTION
## Summary

Fix CI clippy failure on master — replace `.map(|d| Config::normalize_domain(d))` with `.map(Config::normalize_domain)` in test helpers.

## Test plan
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean  
- [x] 30 tests pass