### PR TITLE
fix(njalla): retry transient API failures with exponential backoff

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,5 +13,11 @@ DOMAIN_FILTER=example.com,example.org
 DRY_RUN=false
 CACHE_TTL_SECONDS=60
 
+# Resilience: retry transient Njalla API failures (HTTP 429, 5xx, network
+# errors) with exponential backoff before surfacing an error to external-dns.
+# Total attempts = NJALLA_MAX_RETRIES + 1. Backoff = base * 2^(retry-1), capped.
+NJALLA_MAX_RETRIES=3
+NJALLA_RETRY_BASE_MS=500
+
 # Logging
 RUST_LOG=info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,6 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v17
 
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v3
-
       - name: Check Rust formatting
         run: nix develop -c cargo fmt --all -- --check
 
@@ -45,9 +42,6 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v17
 
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v3
-
       - name: Run tests
         run: nix develop -c cargo test --all-features
 
@@ -58,6 +52,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         target:
           - x86_64-unknown-linux-gnu
@@ -68,9 +63,6 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v17
-
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v3
 
       - name: Build binary
         run: |
@@ -102,9 +94,6 @@ jobs:
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v17
-
-      - name: Setup Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ nix build
 | `DOMAIN_FILTER` | Comma-separated list of domains to manage | All domains | No |
 | `DRY_RUN` | Enable dry-run mode (log changes without applying) | `false` | No |
 | `CACHE_TTL_SECONDS` | DNS records cache TTL in seconds | `60` | No |
+| `NJALLA_MAX_RETRIES` | Retries for transient Njalla API failures (429, 5xx, network). Total attempts = retries + 1 | `3` | No |
+| `NJALLA_RETRY_BASE_MS` | Base delay (ms) for exponential backoff between retries (`base * 2^(retry-1)`, capped at 10s) | `500` | No |
 | `RUST_LOG` | Log level (trace, debug, info, warn, error) | `info` | No |
 
 ### Example .env file
@@ -132,6 +134,8 @@ DOMAIN_FILTER=example.com,example.org
 RUST_LOG=info
 DRY_RUN=false
 CACHE_TTL_SECONDS=60
+NJALLA_MAX_RETRIES=3
+NJALLA_RETRY_BASE_MS=500
 ```
 
 ## Kubernetes Deployment

--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1758690382,
-        "narHash": "sha256-NY3kSorgqE5LMm1LqNwGne3ZLMF2/ILgLpFr1fS4X3o=",
+        "lastModified": 1780011192,
+        "narHash": "sha256-luHrZG6I7Mwdt413XoDOYBpp9z1z6X23/5SNktwjM+k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e643668fd71b949c53f8626614b21ff71a07379d",
+        "rev": "3242faf14b7611a62ce0f0071619438a08b65c12",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixos-unstable-small",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -62,11 +62,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1758940228,
-        "narHash": "sha256-sTS04L9LKqzP1oiVXYDwcMzfFSF0DnSJQFzZBpEgLFE=",
+        "lastModified": 1780024773,
+        "narHash": "sha256-aU9nlrS9S+IJ2EiCzsaxzOXUhggogqTrJojBicE6Oeg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "5bfedf3fbbf5caf8e39f7fcd62238f54d82aa1e2",
+        "rev": "40b0a3a193e0840c76174b4a322874c8f6dd0a63",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,10 @@
   description = "Njalla DNS webhook provider for external-dns";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    # nixos-unstable-small tracks the same packages as nixos-unstable but
+    # advances faster; we need it for the importCargoLock fix that fetches
+    # crates from static.crates.io (crates.io/api now 403s the curl UA).
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable-small";
     flake-utils.url = "github:numtide/flake-utils";
     rust-overlay.url = "github:oxalica/rust-overlay";
   };

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,6 +10,11 @@ pub struct Config {
     pub domain_filter: Option<Vec<String>>,
     pub dry_run: bool,
     pub cache_ttl_seconds: u64,
+    /// Maximum number of retries for a transient Njalla API failure (rate
+    /// limits, 5xx, network errors). Total attempts = retries + 1.
+    pub njalla_max_retries: u32,
+    /// Base delay in milliseconds for the exponential backoff between retries.
+    pub njalla_retry_base_ms: u64,
 }
 
 impl Config {
@@ -40,6 +45,14 @@ impl Config {
             .unwrap_or_else(|_| "60".to_string())
             .parse::<u64>()?;
 
+        let njalla_max_retries = env::var("NJALLA_MAX_RETRIES")
+            .unwrap_or_else(|_| "3".to_string())
+            .parse::<u32>()?;
+
+        let njalla_retry_base_ms = env::var("NJALLA_RETRY_BASE_MS")
+            .unwrap_or_else(|_| "500".to_string())
+            .parse::<u64>()?;
+
         Ok(Config {
             njalla_api_token,
             webhook_host,
@@ -47,6 +60,8 @@ impl Config {
             domain_filter,
             dry_run,
             cache_ttl_seconds,
+            njalla_max_retries,
+            njalla_retry_base_ms,
         })
     }
 
@@ -80,6 +95,8 @@ mod tests {
             domain_filter: Some(domains.into_iter().map(Config::normalize_domain).collect()),
             dry_run: false,
             cache_ttl_seconds: 60,
+            njalla_max_retries: 3,
+            njalla_retry_base_ms: 500,
         }
     }
 
@@ -140,6 +157,8 @@ mod tests {
             domain_filter: None,
             dry_run: false,
             cache_ttl_seconds: 60,
+            njalla_max_retries: 3,
+            njalla_retry_base_ms: 500,
         };
         assert!(config.is_domain_allowed("anything.com"));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,11 @@ async fn main() -> Result<()> {
     );
 
     // Create Njalla client
-    let njalla_client = njalla::Client::new(&config.njalla_api_token)?;
+    let njalla_client = njalla::Client::new(
+        &config.njalla_api_token,
+        config.njalla_max_retries,
+        std::time::Duration::from_millis(config.njalla_retry_base_ms),
+    )?;
 
     // Build the application
     let app = Router::new()

--- a/src/njalla/client.rs
+++ b/src/njalla/client.rs
@@ -1,18 +1,56 @@
 use super::types::*;
 use crate::error::{Error, Result};
-use reqwest::{header, Client as HttpClient};
+use reqwest::{header, Client as HttpClient, StatusCode};
 use serde_json::json;
 use std::time::Duration;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 const NJALLA_API_URL: &str = "https://njal.la/api/1/";
 
+/// Upper bound on the exponential backoff delay between retries.
+const MAX_BACKOFF: Duration = Duration::from_secs(10);
+
+/// Outcome of a single Njalla API attempt that failed, carrying whether the
+/// failure is worth retrying.
+struct AttemptError {
+    error: Error,
+    retryable: bool,
+}
+
+/// A non-2xx HTTP status from Njalla is retryable when it is a rate-limit
+/// (429) or a transient server-side error (5xx). All other statuses (4xx)
+/// reflect a deterministic problem with the request and are not retried.
+fn is_retryable_status(status: StatusCode) -> bool {
+    status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error()
+}
+
+/// Exponential backoff: `base * 2^(retry - 1)`, capped at `MAX_BACKOFF`.
+/// `retry` is 1-based (the delay before the first retry uses `retry == 1`).
+fn backoff_delay(base: Duration, retry: u32) -> Duration {
+    let factor = 2u32.saturating_pow(retry.saturating_sub(1));
+    base.checked_mul(factor)
+        .unwrap_or(MAX_BACKOFF)
+        .min(MAX_BACKOFF)
+}
+
 pub struct Client {
     http_client: HttpClient,
+    api_url: String,
+    max_retries: u32,
+    retry_base: Duration,
 }
 
 impl Client {
-    pub fn new(api_token: &str) -> Result<Self> {
+    pub fn new(api_token: &str, max_retries: u32, retry_base: Duration) -> Result<Self> {
+        Self::with_api_url(api_token, max_retries, retry_base, NJALLA_API_URL)
+    }
+
+    fn with_api_url(
+        api_token: &str,
+        max_retries: u32,
+        retry_base: Duration,
+        api_url: &str,
+    ) -> Result<Self> {
         let mut headers = header::HeaderMap::new();
         headers.insert(
             header::AUTHORIZATION,
@@ -30,40 +68,116 @@ impl Client {
             .build()
             .map_err(|e| Error::Configuration(format!("Failed to create HTTP client: {}", e)))?;
 
-        Ok(Self { http_client })
+        Ok(Self {
+            http_client,
+            api_url: api_url.to_string(),
+            max_retries,
+            retry_base,
+        })
     }
 
+    /// Call the Njalla API, retrying transient failures (rate limits, 5xx,
+    /// network errors) with exponential backoff. A single failed call used to
+    /// bubble up as a hard error, which external-dns treats as a fatal
+    /// "apply changes" failure and crashes on — so absorbing transient blips
+    /// here keeps the reconcile loop alive.
+    ///
+    /// Note: mutating calls (add/remove-record) are retried as well. This is
+    /// safe in practice because external-dns already re-runs the entire change
+    /// batch on the next reconcile, so a retry is no worse than the existing
+    /// crash-and-retry behaviour, and the common transient case (a 429/5xx
+    /// where Njalla rejected the request outright) makes no change to retry.
     async fn call_api<T>(&self, request: JsonRpcRequest) -> Result<T>
+    where
+        T: for<'de> serde::Deserialize<'de>,
+    {
+        let mut retries = 0u32;
+        loop {
+            match self.attempt_call_api::<T>(&request).await {
+                Ok(value) => return Ok(value),
+                Err(AttemptError { error, retryable }) => {
+                    if retryable && retries < self.max_retries {
+                        retries += 1;
+                        let delay = backoff_delay(self.retry_base, retries);
+                        warn!(
+                            "Njalla API '{}' failed (attempt {}/{}): {} — retrying in {:?}",
+                            request.method,
+                            retries,
+                            self.max_retries + 1,
+                            error,
+                            delay
+                        );
+                        tokio::time::sleep(delay).await;
+                        continue;
+                    }
+                    return Err(error);
+                }
+            }
+        }
+    }
+
+    /// Perform a single API attempt, classifying any failure as retryable or
+    /// terminal.
+    async fn attempt_call_api<T>(
+        &self,
+        request: &JsonRpcRequest,
+    ) -> std::result::Result<T, AttemptError>
     where
         T: for<'de> serde::Deserialize<'de>,
     {
         debug!("Calling Njalla API: method={}", request.method);
 
-        let response = self
+        let response = match self
             .http_client
-            .post(NJALLA_API_URL)
-            .json(&request)
+            .post(&self.api_url)
+            .json(request)
             .send()
-            .await?;
+            .await
+        {
+            Ok(response) => response,
+            // Connect/timeout/transport errors are transient.
+            Err(e) => {
+                return Err(AttemptError {
+                    retryable: true,
+                    error: Error::Network(e),
+                });
+            }
+        };
 
-        if !response.status().is_success() {
-            let status = response.status();
+        let status = response.status();
+        if !status.is_success() {
+            let retryable = is_retryable_status(status);
             let text = response.text().await.unwrap_or_default();
-            return Err(Error::NjallaApi(format!("HTTP {}: {}", status, text)));
+            return Err(AttemptError {
+                retryable,
+                error: Error::NjallaApi(format!("HTTP {}: {}", status, text)),
+            });
         }
 
-        let json_response: JsonRpcResponse<T> = response.json().await?;
+        let json_response: JsonRpcResponse<T> = match response.json().await {
+            Ok(parsed) => parsed,
+            // A 2xx body that fails to decode is likely a truncated/transient
+            // response; allow a retry.
+            Err(e) => {
+                return Err(AttemptError {
+                    retryable: true,
+                    error: Error::Network(e),
+                });
+            }
+        };
 
         if let Some(error) = json_response.error {
-            return Err(Error::NjallaApi(format!(
-                "API error {}: {}",
-                error.code, error.message
-            )));
+            // JSON-RPC application errors are deterministic; do not retry.
+            return Err(AttemptError {
+                retryable: false,
+                error: Error::NjallaApi(format!("API error {}: {}", error.code, error.message)),
+            });
         }
 
-        json_response
-            .result
-            .ok_or_else(|| Error::NjallaApi("Empty response from Njalla API".to_string()))
+        json_response.result.ok_or_else(|| AttemptError {
+            retryable: false,
+            error: Error::NjallaApi("Empty response from Njalla API".to_string()),
+        })
     }
 
     pub async fn list_domains(&self) -> Result<Vec<Domain>> {
@@ -155,5 +269,142 @@ impl Client {
             request.id, request.domain
         );
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rate_limit_and_server_errors_are_retryable() {
+        assert!(is_retryable_status(StatusCode::TOO_MANY_REQUESTS));
+        assert!(is_retryable_status(StatusCode::INTERNAL_SERVER_ERROR));
+        assert!(is_retryable_status(StatusCode::BAD_GATEWAY));
+        assert!(is_retryable_status(StatusCode::SERVICE_UNAVAILABLE));
+        assert!(is_retryable_status(StatusCode::GATEWAY_TIMEOUT));
+    }
+
+    #[test]
+    fn client_errors_are_not_retryable() {
+        assert!(!is_retryable_status(StatusCode::BAD_REQUEST));
+        assert!(!is_retryable_status(StatusCode::UNAUTHORIZED));
+        assert!(!is_retryable_status(StatusCode::FORBIDDEN));
+        assert!(!is_retryable_status(StatusCode::NOT_FOUND));
+    }
+
+    #[test]
+    fn backoff_grows_exponentially() {
+        let base = Duration::from_millis(500);
+        assert_eq!(backoff_delay(base, 1), Duration::from_millis(500));
+        assert_eq!(backoff_delay(base, 2), Duration::from_millis(1000));
+        assert_eq!(backoff_delay(base, 3), Duration::from_millis(2000));
+        assert_eq!(backoff_delay(base, 4), Duration::from_millis(4000));
+    }
+
+    #[test]
+    fn backoff_is_capped_and_overflow_safe() {
+        let base = Duration::from_millis(500);
+        // Large retry counts must saturate at MAX_BACKOFF rather than overflow.
+        assert_eq!(backoff_delay(base, 100), MAX_BACKOFF);
+        assert_eq!(backoff_delay(Duration::from_secs(3600), 5), MAX_BACKOFF);
+    }
+
+    fn test_client(server: &mockito::Server, max_retries: u32) -> Client {
+        // Near-zero backoff keeps the tests fast.
+        Client::with_api_url(
+            "token",
+            max_retries,
+            Duration::from_millis(1),
+            &server.url(),
+        )
+        .expect("client should build")
+    }
+
+    const SUCCESS_BODY: &str = r#"{"jsonrpc":"2.0","result":{"domains":[]},"id":1}"#;
+
+    #[tokio::test]
+    async fn retries_transient_failure_then_succeeds() {
+        let mut server = mockito::Server::new_async().await;
+        // First attempt: rate-limited. Mockito serves mocks in creation order
+        // until each is exhausted, so the 429 fires once, then the 200.
+        let rate_limited = server
+            .mock("POST", "/")
+            .with_status(429)
+            .with_body("rate limited")
+            .expect(1)
+            .create_async()
+            .await;
+        let ok = server
+            .mock("POST", "/")
+            .with_status(200)
+            .with_body(SUCCESS_BODY)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let client = test_client(&server, 3);
+        let result = client.list_domains().await;
+
+        assert!(result.is_ok(), "expected success after retry: {result:?}");
+        rate_limited.assert_async().await;
+        ok.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn gives_up_after_max_retries_on_server_error() {
+        let mut server = mockito::Server::new_async().await;
+        // max_retries = 2 → 3 total attempts, all 503.
+        let always_500 = server
+            .mock("POST", "/")
+            .with_status(503)
+            .with_body("unavailable")
+            .expect(3)
+            .create_async()
+            .await;
+
+        let client = test_client(&server, 2);
+        let result = client.list_domains().await;
+
+        assert!(result.is_err(), "expected failure after exhausting retries");
+        always_500.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn does_not_retry_on_client_error() {
+        let mut server = mockito::Server::new_async().await;
+        // A 400 is deterministic and must be attempted exactly once.
+        let bad_request = server
+            .mock("POST", "/")
+            .with_status(400)
+            .with_body("bad request")
+            .expect(1)
+            .create_async()
+            .await;
+
+        let client = test_client(&server, 3);
+        let result = client.list_domains().await;
+
+        assert!(result.is_err(), "client error must surface");
+        bad_request.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn does_not_retry_on_jsonrpc_application_error() {
+        let mut server = mockito::Server::new_async().await;
+        // A 200 carrying a JSON-RPC error is deterministic: attempt once.
+        let app_error = server
+            .mock("POST", "/")
+            .with_status(200)
+            .with_body(r#"{"jsonrpc":"2.0","error":{"code":403,"message":"forbidden"},"id":1}"#)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let client = test_client(&server, 3);
+        let result = client.list_domains().await;
+
+        assert!(result.is_err(), "application error must surface");
+        app_error.assert_async().await;
     }
 }

--- a/src/webhook/handlers.rs
+++ b/src/webhook/handlers.rs
@@ -455,9 +455,14 @@ mod tests {
             domain_filter: Some(vec![Config::normalize_domain("example.com")]),
             dry_run: true,
             cache_ttl_seconds: 60,
+            njalla_max_retries: 3,
+            njalla_retry_base_ms: 500,
         };
 
-        let client = Arc::new(NjallaClient::new("dummy-token").expect("client should build"));
+        let client = Arc::new(
+            NjallaClient::new("dummy-token", 0, std::time::Duration::from_millis(0))
+                .expect("client should build"),
+        );
         WebhookHandler::new(client, config)
     }
 
@@ -489,8 +494,13 @@ mod tests {
             domain_filter: Some(domains.into_iter().map(Config::normalize_domain).collect()),
             dry_run: true,
             cache_ttl_seconds: 60,
+            njalla_max_retries: 3,
+            njalla_retry_base_ms: 500,
         };
-        let client = Arc::new(NjallaClient::new("dummy-token").expect("client should build"));
+        let client = Arc::new(
+            NjallaClient::new("dummy-token", 0, std::time::Duration::from_millis(0))
+                .expect("client should build"),
+        );
         WebhookHandler::new(client, config)
     }
 
@@ -502,6 +512,8 @@ mod tests {
             domain_filter: None,
             dry_run: true,
             cache_ttl_seconds: 60,
+            njalla_max_retries: 3,
+            njalla_retry_base_ms: 500,
         };
 
         let mock_lister = Arc::new(MockDomainLister {
@@ -515,7 +527,10 @@ mod tests {
                 .collect(),
         });
 
-        let client = Arc::new(NjallaClient::new("dummy-token").expect("client should build"));
+        let client = Arc::new(
+            NjallaClient::new("dummy-token", 0, std::time::Duration::from_millis(0))
+                .expect("client should build"),
+        );
         WebhookHandler {
             njalla_client: client,
             domain_lister: mock_lister,
@@ -624,8 +639,13 @@ mod tests {
             domain_filter: Some(vec!["example.com".to_string()]),
             dry_run: true,
             cache_ttl_seconds: 60,
+            njalla_max_retries: 3,
+            njalla_retry_base_ms: 500,
         };
-        let client = Arc::new(NjallaClient::new("dummy-token").expect("client should build"));
+        let client = Arc::new(
+            NjallaClient::new("dummy-token", 0, std::time::Duration::from_millis(0))
+                .expect("client should build"),
+        );
         let handler = WebhookHandler {
             njalla_client: client,
             domain_lister: Arc::new(PanickingDomainLister),


### PR DESCRIPTION
## Summary

A single failed Njalla API call during `apply_changes` currently bubbles up as a hard error and the webhook returns HTTP 500. external-dns treats any non-2xx from the webhook as a **fatal** apply failure and exits — so one transient Njalla blip (a rate limit or a brief 5xx) crash-loops the entire reconcile process. In production this manifests as external-dns restarting roughly daily with:

```
level=fatal msg="failed to apply changes with code 500"
```

The webhook itself is healthy; the 500 comes from `apply_changes` aggregating a `Partial failure: N succeeded, M failed`, where the failing op was a transient Njalla API error with no retry to absorb it. The likelihood is amplified on accounts with many records: a change batch fires a burst of API calls (and `delete_endpoint` re-lists records per endpoint), raising the odds of hitting a rate limit.

## Changes

- Add retry-with-backoff to the Njalla API client (`src/njalla/client.rs`):
  - **Retryable**: HTTP 429, HTTP 5xx, and connect/timeout/transport errors, plus a failed decode of a 2xx body.
  - **Not retried**: 4xx other than 429, and JSON-RPC application errors — these are deterministic.
  - Capped exponential backoff: `base * 2^(retry-1)`, clamped to 10s, overflow-safe.
- Make it configurable (`src/config.rs`, `src/main.rs`):
  - `NJALLA_MAX_RETRIES` (default `3`; total attempts = retries + 1)
  - `NJALLA_RETRY_BASE_MS` (default `500`)
- Document both env vars in `README.md` and `.env.example`.

Mutating calls (`add-record`/`remove-record`) are retried too. This is safe in practice: external-dns already re-runs the whole change batch on the next reconcile, so a retry is no worse than the existing crash-and-retry, and the dominant transient case (a 429/5xx where Njalla rejected the request outright) applies no change.

## Test Plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features` — 39 pass
- [x] New unit tests: retryable-status classification, exponential-backoff growth + cap/overflow safety
- [x] New mockito integration tests: retry-then-success on 429, give-up after max retries on 503, no-retry on 400, no-retry on JSON-RPC application error

## Impact

No behavior change on the happy path or for deterministic errors. Transient Njalla failures are now absorbed (up to the retry budget) instead of propagating a 500 that crashes external-dns. Defaults are conservative; both knobs are tunable via env.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable retry mechanism for Njalla API operations with exponential backoff.
  * Two new environment variables: NJALLA_MAX_RETRIES (default: 3) and NJALLA_RETRY_BASE_MS (default: 500ms).

* **Documentation**
  * Updated configuration docs and examples to include the new retry variables.

* **Tests**
  * Added tests validating retry behavior and classifications.

* **Chores**
  * Adjusted CI workflow steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/douglaz/njalla-webhook/pull/32?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->