### PR TITLE
fix(webhook): make record creation idempotent

### DIFF
--- a/src/webhook/handlers.rs
+++ b/src/webhook/handlers.rs
@@ -276,7 +276,43 @@ impl WebhookHandler {
 
         let name = self.extract_record_name(&endpoint.dns_name, &zone);
 
+        // Fetch existing records once so creation is idempotent. Njalla's
+        // `add-record` always appends a new record (there is no upsert and no
+        // uniqueness constraint), so a redundant CREATE — which external-dns
+        // emits whenever its view of current records is missing this entry
+        // (registry TXT format change, a transient list failure, a restart) —
+        // silently produces a duplicate. Repeated over many reconciliations
+        // this floods the zone with thousands of copies and eventually makes
+        // the authoritative nameservers fail to serve it (SERVFAIL).
+        // Skipped in dry-run, which must not touch the API at all.
+        let existing = if self.config.dry_run {
+            Vec::new()
+        } else {
+            self.njalla_client.list_records(&zone).await?
+        };
+
         for target in &endpoint.targets {
+            // Skip if an identical record (same name/type/content) already
+            // exists. Name normalization mirrors `delete_endpoint`.
+            let already_exists = existing.iter().any(|record| {
+                let record_name = if record.name.is_empty() || record.name == "@" {
+                    ""
+                } else {
+                    record.name.as_str()
+                };
+                record_name == name.as_str()
+                    && record.record_type == endpoint.record_type
+                    && record.content == *target
+            });
+
+            if already_exists {
+                info!(
+                    "Record already exists, skipping create: {} {} -> {}",
+                    endpoint.record_type, endpoint.dns_name, target
+                );
+                continue;
+            }
+
             let priority = endpoint
                 .provider_specific
                 .iter()


### PR DESCRIPTION
## Problem

`create_endpoint` called Njalla `add-record` unconditionally. Njalla's
`add-record` always **appends** a new record — there is no upsert and no
uniqueness constraint — so any redundant `CREATE` that external-dns emits
(after a registry-TXT format change, a transient `list-records` failure, or
a pod restart) silently produced a duplicate record.

Over many reconciliations this accumulated **~140 copies of every record**
(1287 records where only 17 were real) in a production zone, until Njalla's
authoritative nameservers could no longer serve it and returned **SERVFAIL**
for the entire zone — taking every host in it offline (observed as a 503 on
the monitored endpoints).

## Fix

Make creation idempotent: fetch existing records once and skip `add-record`
when an identical `(name, type, content)` record already exists, using the
same name normalization as `delete_endpoint`. The lookup is skipped in
dry-run so that path still performs zero API calls.

This covers all create paths — direct creates and `update_endpoint`
(delete-old + create-new) both route through `create_endpoint`.

## Validation

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and the
  full test suite pass.
- Reviewed with `codex` (gpt-5.5). Verdict: correct and complete for the
  reported flood.

## Known follow-ups (out of scope, surfaced by review)

- **Retried `add-record`**: a mutating `add-record` that is appended by
  Njalla but whose response is lost could still be re-appended on retry (the
  precheck runs only before the call). Pre-existing behaviour from #32; rare
  vs. the per-reconcile flood fixed here.
- Case-insensitive name/type matching and MX/SRV `priority` in the dedupe
  key — not relevant to the affected A/CNAME/TXT zone, and case-sensitivity
  intentionally mirrors `delete_endpoint`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNS record creation to be idempotent, preventing duplicate records from accumulating across multiple reconciliations. The system now checks for existing records before adding new ones and skips creation if an identical record is already present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->