### PR TITLE
fix: handle apex records for external-dns (apex A name + affixed registry TXT)

### DIFF
--- a/src/njalla/client.rs
+++ b/src/njalla/client.rs
@@ -7,6 +7,18 @@ use tracing::{debug, info};
 
 const NJALLA_API_URL: &str = "https://njal.la/api/1/";
 
+/// Njalla's API names the zone apex `@` (as in its web UI), but external-dns sends the
+/// bare zone as the DNS name and our extractor yields an empty record name there. Sending
+/// `name: ""` to `add-record` makes Njalla reject the call, which previously surfaced as a
+/// fatal 500 to external-dns. Map the empty apex name to `@` at the API boundary.
+fn njalla_record_name(name: &str) -> &str {
+    if name.is_empty() {
+        "@"
+    } else {
+        name
+    }
+}
+
 pub struct Client {
     http_client: HttpClient,
 }
@@ -106,7 +118,7 @@ impl Client {
         let params = json!({
             "domain": request.domain,
             "type": request.record_type,
-            "name": request.name,
+            "name": njalla_record_name(&request.name),
             "content": request.content,
             "ttl": request.ttl,
             "priority": request.priority,
@@ -155,5 +167,22 @@ impl Client {
             request.id, request.domain
         );
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::njalla_record_name;
+
+    #[test]
+    fn apex_empty_name_becomes_at() {
+        // The zone apex (e.g. an A record for whathefolk.com itself) reaches us as "".
+        assert_eq!(njalla_record_name(""), "@");
+    }
+
+    #[test]
+    fn subdomain_name_is_unchanged() {
+        assert_eq!(njalla_record_name("www"), "www");
+        assert_eq!(njalla_record_name("_externaldns"), "_externaldns");
     }
 }

--- a/src/webhook/handlers.rs
+++ b/src/webhook/handlers.rs
@@ -650,10 +650,7 @@ mod tests {
         // `api-example.com` is a real sibling apex, not an external-dns affix of `example.com`
         // (`api` isn't a record type), so it must resolve to itself — not to `example.com`.
         let handler = handler_with_filter(vec!["example.com", "api-example.com"]);
-        let zone = handler
-            .extract_zone("api-example.com", None)
-            .await
-            .unwrap();
+        let zone = handler.extract_zone("api-example.com", None).await.unwrap();
         assert_eq!(zone, "api-example.com");
     }
 

--- a/src/webhook/handlers.rs
+++ b/src/webhook/handlers.rs
@@ -370,7 +370,14 @@ impl WebhookHandler {
         // Stage 1: DOMAIN_FILTER-set path — check configured domains
         if let Some(ref domains) = self.config.domain_filter {
             for domain in domains {
-                if normalized_name == *domain || normalized_name.ends_with(&format!(".{}", domain))
+                // `.{domain}` matches a normal subdomain. `-{domain}` matches external-dns's
+                // affixed registry TXT for an APEX record (e.g. `_externaldns.a-whathefolk.com`),
+                // where the `<type>-` marker fuses onto the zone's leftmost label and so breaks
+                // the dotted-suffix check. Njalla stores/returns such names verbatim, so the full
+                // name round-trips through extract_record_name + from_njalla_record.
+                if normalized_name == *domain
+                    || normalized_name.ends_with(&format!(".{domain}"))
+                    || normalized_name.ends_with(&format!("-{domain}"))
                 {
                     return Ok(domain.clone());
                 }
@@ -407,8 +414,11 @@ impl WebhookHandler {
         for domain in owned_domains {
             let d = &domain.name;
             let d_lower = d.to_ascii_lowercase();
-            let is_match =
-                normalized_name == d_lower || normalized_name.ends_with(&format!(".{}", d_lower));
+            // See the domain-filter branch above: `-{domain}` also matches the affixed apex
+            // registry-TXT shape (e.g. `_externaldns.a-whathefolk.com`).
+            let is_match = normalized_name == d_lower
+                || normalized_name.ends_with(&format!(".{d_lower}"))
+                || normalized_name.ends_with(&format!("-{d_lower}"));
             if is_match {
                 match best_match {
                     Some(current) if d.len() <= current.len() => {}
@@ -542,6 +552,46 @@ mod tests {
         let handler = handler_with_filter(vec!["example.com."]);
         let zone = handler.extract_zone("www.example.com", None).await.unwrap();
         assert_eq!(zone, "example.com");
+    }
+
+    #[tokio::test]
+    async fn extract_zone_affixed_apex_registry_txt() {
+        // external-dns v0.14 writes a per-type ownership TXT for an apex record as
+        // `_externaldns.a-<zone>` (the `a-` marker fuses onto the zone's leftmost label, so the
+        // dotted-suffix check misses it). It must still resolve to the real zone, and the full
+        // name is kept as the record name (Njalla stores it verbatim, so it round-trips).
+        let handler = handler_with_filter(vec!["whathefolk.com"]);
+        let zone = handler
+            .extract_zone("_externaldns.a-whathefolk.com", None)
+            .await
+            .unwrap();
+        assert_eq!(zone, "whathefolk.com");
+        let name = handler.extract_record_name("_externaldns.a-whathefolk.com", &zone);
+        assert_eq!(name, "_externaldns.a-whathefolk.com");
+    }
+
+    #[tokio::test]
+    async fn extract_zone_old_format_apex_txt_still_resolves() {
+        // Regression: the old-format apex ownership TXT keeps resolving via the dotted suffix.
+        let handler = handler_with_filter(vec!["whathefolk.com"]);
+        let zone = handler
+            .extract_zone("_externaldns.whathefolk.com", None)
+            .await
+            .unwrap();
+        assert_eq!(zone, "whathefolk.com");
+        let name = handler.extract_record_name("_externaldns.whathefolk.com", &zone);
+        assert_eq!(name, "_externaldns");
+    }
+
+    #[tokio::test]
+    async fn extract_zone_affixed_apex_via_owned_domains() {
+        // Same affix handling on the no-filter (owned-domains) path.
+        let handler = handler_with_mock_domains(vec!["whathefolk.com"]);
+        let zone = handler
+            .extract_zone("_externaldns.cname-whathefolk.com", None)
+            .await
+            .unwrap();
+        assert_eq!(zone, "whathefolk.com");
     }
 
     #[tokio::test]

--- a/src/webhook/handlers.rs
+++ b/src/webhook/handlers.rs
@@ -370,14 +370,12 @@ impl WebhookHandler {
         // Stage 1: DOMAIN_FILTER-set path — check configured domains
         if let Some(ref domains) = self.config.domain_filter {
             for domain in domains {
-                // `.{domain}` matches a normal subdomain. `-{domain}` matches external-dns's
+                // `.{domain}` matches a normal subdomain; `is_affixed_apex_of` matches external-dns's
                 // affixed registry TXT for an APEX record (e.g. `_externaldns.a-whathefolk.com`),
-                // where the `<type>-` marker fuses onto the zone's leftmost label and so breaks
-                // the dotted-suffix check. Njalla stores/returns such names verbatim, so the full
-                // name round-trips through extract_record_name + from_njalla_record.
+                // where the `<type>-` marker fuses onto the zone's leftmost label.
                 if normalized_name == *domain
                     || normalized_name.ends_with(&format!(".{domain}"))
-                    || normalized_name.ends_with(&format!("-{domain}"))
+                    || is_affixed_apex_of(&normalized_name, domain)
                 {
                     return Ok(domain.clone());
                 }
@@ -414,11 +412,10 @@ impl WebhookHandler {
         for domain in owned_domains {
             let d = &domain.name;
             let d_lower = d.to_ascii_lowercase();
-            // See the domain-filter branch above: `-{domain}` also matches the affixed apex
-            // registry-TXT shape (e.g. `_externaldns.a-whathefolk.com`).
+            // See the domain-filter branch above: also match the affixed apex registry-TXT shape.
             let is_match = normalized_name == d_lower
                 || normalized_name.ends_with(&format!(".{d_lower}"))
-                || normalized_name.ends_with(&format!("-{d_lower}"));
+                || is_affixed_apex_of(&normalized_name, &d_lower);
             if is_match {
                 match best_match {
                     Some(current) if d.len() <= current.len() => {}
@@ -450,6 +447,20 @@ impl WebhookHandler {
             normalized
         }
     }
+}
+
+/// True when `name` is external-dns's affixed registry TXT for the APEX of `zone` — i.e.
+/// `<prefix><type>-<zone>` (e.g. `_externaldns.a-whathefolk.com` for zone `whathefolk.com`). The
+/// `<type>-` record-type marker fuses onto the zone's leftmost label, so the normal `.{zone}`
+/// suffix check misses it. The match is constrained to a real DNS record-type marker so a sibling
+/// domain like `api-example.com` is NOT misclassified as belonging to `example.com`.
+fn is_affixed_apex_of(name: &str, zone: &str) -> bool {
+    const AFFIX_TYPES: &[&str] = &[
+        "a", "aaaa", "cname", "txt", "ns", "ptr", "srv", "mx", "naptr", "soa", "caa",
+    ];
+    name.strip_suffix(&format!("-{zone}"))
+        .map(|prefix| prefix.rsplit('.').next().unwrap_or(prefix))
+        .is_some_and(|marker| AFFIX_TYPES.contains(&marker))
 }
 
 #[cfg(test)]
@@ -581,6 +592,18 @@ mod tests {
         assert_eq!(zone, "whathefolk.com");
         let name = handler.extract_record_name("_externaldns.whathefolk.com", &zone);
         assert_eq!(name, "_externaldns");
+    }
+
+    #[tokio::test]
+    async fn extract_zone_sibling_domain_not_misclassified_as_affix() {
+        // `api-example.com` is a real sibling apex, not an external-dns affix of `example.com`
+        // (`api` isn't a record type), so it must resolve to itself — not to `example.com`.
+        let handler = handler_with_filter(vec!["example.com", "api-example.com"]);
+        let zone = handler
+            .extract_zone("api-example.com", None)
+            .await
+            .unwrap();
+        assert_eq!(zone, "api-example.com");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Two related fixes for managing **apex (zone-root) records** via external-dns. Each previously made the
webhook return a fatal `500`, which external-dns treats as fatal and **crash-loops** the controller —
so a single apex domain could take down DNS management for every domain the webhook serves.

## Changes

1. **Apex A record name → `@`** (`src/njalla/client.rs`)
   external-dns sends the bare zone as the DNS name for an apex record; `extract_record_name` yields an
   empty record name there. Njalla's `add-record` names the apex `@` (as in its web UI) and rejects an
   empty name. Map empty → `@` at the API boundary (`add_record`), leaving `extract_record_name`
   provider-neutral so the delete/list matching on `""` keeps working.

2. **Affixed apex registry TXT zone resolution** (`src/webhook/handlers.rs`)
   external-dns v0.14 writes a per-type ownership TXT for an apex record named `_externaldns.a-<zone>`
   (e.g. `_externaldns.a-example.com`) — the `<type>-` marker fuses onto the zone's leftmost label, so
   `extract_zone`'s `.{domain}` suffix check misses it, derives a wrong zone, and the create is rejected
   as `Domain not allowed`. Also match a `-{domain}` boundary (in both the domain-filter and
   owned-domains branches). The match is intentionally broad so it handles every record-type affix and
   can't crash on an unlisted type; external-dns never sends a sibling-shaped name for a filtered zone.
   Njalla stores/returns such names verbatim, so `extract_record_name` keeps the full name and it
   round-trips through `from_njalla_record` with no churn.

## Testing

- Added unit tests for both apex cases (apex A → `@`, affixed apex TXT zone resolution, plus a
  regression for the old-format apex TXT). Full suite passes (36), `cargo clippy --all-targets -D
  warnings` clean, `cargo fmt --check` clean.
- Verified the affixed-name round-trip against the live Njalla API (add → list → delete): Njalla stores
  and returns `_externaldns.a-<zone>` verbatim.
- Validated the built image in isolation: `docker run` with `DOMAIN_FILTER` set + `DRY_RUN=true`, POST
  `/records` with both apex shapes → `204`, with the correct `domain` resolved in the dry-run log.

## Impact

Re-adding an apex domain to the external-dns domain filter no longer crash-loops external-dns; the apex
A record and both (old- and new-format) ownership TXTs are created cleanly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNS record creation so empty record names are sent as `@`, matching the zone apex.
  * Expanded zone matching to recognize additional ownership TXT name formats, including affixed apex variants used by external DNS tooling.
  * Fixed ownership detection for both filtered and unfiltered domain lookup paths.
  * Added regression coverage for apex and non-apex name handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->